### PR TITLE
Vercel/set up vercel speed insights t d0gsbv

### DIFF
--- a/.vscode/devmirror/cli.js
+++ b/.vscode/devmirror/cli.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const config = JSON.parse(fs.readFileSync(path.join(__dirname, 'config.json'), 'utf8'));
+const cli = config.cliPath;
+require(cli);

--- a/.vscode/devmirror/config.json
+++ b/.vscode/devmirror/config.json
@@ -1,0 +1,4 @@
+{
+  "extensionPath": "c:\\Users\\lukas\\.vscode\\extensions\\ivgdesign.devmirror-0.4.82",
+  "cliPath": "c:\\Users\\lukas\\.vscode\\extensions\\ivgdesign.devmirror-0.4.82\\out\\cli.js"
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `.vscode/devmirror/cli.js` and `.vscode/devmirror/config.json` to run the VS Code `ivgdesign.devmirror` CLI from this repo. The loader reads `cliPath` from the config and executes the extension’s CLI.

- **Migration**
  - Update `.vscode/devmirror/config.json` with your local `extensionPath` and `cliPath` (current values are Windows-specific).
  - If the extension updates or you use macOS/Linux, adjust the paths before running the loader.

<sup>Written for commit 05ba27ec5e652ba5c15058c64168f66ec72ab62e. Summary will update on new commits. <a href="https://cubic.dev/pr/BtS-Style/bts-nexus-protocol/pull/27?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

